### PR TITLE
Fix incorrect attribute used to enable the test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ configured the required test framework attribute. Simply add the following to yo
 
 ```xml
 <ItemGroup>
-  <AssemblyVersionAttribute Include="Xunit.TestFrameworkAttribute">
+  <AssemblyAttribute Include="Xunit.TestFrameworkAttribute">
     <_Parameter1>Xunit.Harness.IdeTestFramework</_Parameter1>
     <_Parameter2>Microsoft.VisualStudio.Extensibility.Testing.Xunit</_Parameter2>
-  </AssemblyVersionAttribute>
+  </AssemblyAttribute>
 </ItemGroup>
 ```
 

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
@@ -29,10 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AssemblyVersionAttribute Include="Xunit.TestFrameworkAttribute">
+    <AssemblyAttribute Include="Xunit.TestFrameworkAttribute">
       <_Parameter1>Xunit.Harness.IdeTestFramework</_Parameter1>
       <_Parameter2>Microsoft.VisualStudio.Extensibility.Testing.Xunit</_Parameter2>
-    </AssemblyVersionAttribute>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`AssemblyVersionAttribute` was a Roslyn-specific item used in a custom build. The normal item used for this purpose by SDK projects is `AssemblyAttribute`.