### PR TITLE
Require Visual Studio 2022 for development

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" Version="17.0.0-previews-1-31310-052" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" Version="17.0.0-previews-1-31310-052" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="all" />
     <PackageReference Include="xunit.assert" Version="2.3.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Dev11/Microsoft.VisualStudio.IntegrationTestService.Dev11.csproj
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Dev11/Microsoft.VisualStudio.IntegrationTestService.Dev11.csproj
@@ -6,6 +6,10 @@
     <Description>Integration test service extension for Visual Studio 2012-2019</Description>
     <RootNamespace>Microsoft.VisualStudio.IntegrationTestService</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.IntegrationTestService</AssemblyName>
+
+    <!-- Force the use of VsSDKX86ToolsPath, which uses binaries from 15.9.3039 -->
+    <BuildArchitecture>x86</BuildArchitecture>
+    <VsSDKX86ToolsPath>$(NuGetPackageRoot)microsoft.vssdk.buildtools\15.9.3039\tools\vssdk\bin</VsSDKX86ToolsPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -28,7 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.1.192" PrivateAssets="all" />
+    <!-- Microsoft.VSSDK.BuildTools 17.0.3155 contains x86 targets, but they have broken dependencies. -->
+    <PackageDownload Include="Microsoft.VSSDK.BuildTools" Version="[15.9.3039]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.3155-preview3" PrivateAssets="all" />
     <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" PrivateAssets="all" />
   </ItemGroup>
 
@@ -49,5 +58,23 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+
+  <UsingTask TaskName="FixVsSDKEnvironmentVariables" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <VsSDKToolsPath Required="true" />
+      <VsSDKX86ToolsPath Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs">
+        System.Environment.SetEnvironmentVariable("VsSDKToolsPath", System.IO.Path.GetFullPath(VsSDKToolsPath),EnvironmentVariableTarget.Process);
+        System.Environment.SetEnvironmentVariable("VsSDKX86ToolsPath", System.IO.Path.GetFullPath(VsSDKX86ToolsPath),EnvironmentVariableTarget.Process);
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- SetVsSDKEnvironmentVariables uses the wrong MSBuild variables to set environment variables, so fix them here. -->
+  <Target Name="FixVsSDKEnvironmentVariables" AfterTargets="SetVsSDKEnvironmentVariables">
+    <FixVsSDKEnvironmentVariables VsSDKToolsPath="$(VsSDKToolsPath)" VsSDKX86ToolsPath="$(VsSDKX86ToolsPath)" />
+  </Target>
 
 </Project>

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk" Version="17.0.0-previews-1-31310-052" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.3155-preview3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.SupportFiles" GeneratePathProperty="true" Version="1.1.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31318-291" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="17.0.0-previews-1-31318-291" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="17.0.0-previews-1-31410-258" />
   </ItemGroup>
 
   <Import Project="..\Microsoft.VisualStudio.VsixInstaller.Shared\Microsoft.VisualStudio.VsixInstaller.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
📝 This change updates the requirements for developing inside dotnet/vs-extension-testing. Downstream consumers are not affected.