### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ instance of Visual Studio.
 
 ## Install the test harness
 
-### Install the *to be determined* package
+### Install the test package for the applicable version(s) of Visual Studio
 
-*TODO*
+| Visual Studio Version | Integration Testing Package |
+| --- | --- |
+| 2022 | Microsoft.VisualStudio.Extensibility.Testing.Xunit |
+| 2012 - 2019 | Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy |
 
 ### Configure the test framework
 

--- a/README.md
+++ b/README.md
@@ -28,20 +28,6 @@ instance of Visual Studio.
 
 *TODO*
 
-### Configure the `appDomain` xUnit property
-
-1. Add a file **xunit.runner.json** to the test project if it does not already exist
-2. Set the **Copy to Output Directory** property for the file to **Copy if newer**
-3. Update the file to set the `appDomain` property to `denied`:
-
-    ```json
-    {
-      "appDomain": "denied"
-    }
-    ```
-
-:link: See https://github.com/Microsoft/vs-extension-testing/issues/3
-
 ### Configure the test framework
 
 #### Classic projects

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -15,6 +15,7 @@ trigger:
 #  branches:
 #    include:
 #    - microbuild
+pr: none
 
 parameters:
 - name: SignTypeSelection

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk" Version="17.0.0-previews-1-31310-052" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/xunit.runner.json
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/xunit.runner.json
@@ -1,3 +1,3 @@
 {
-  "appDomain": "denied"
+  "shadowCopy": false
 }

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.IntegrationTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="12.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30111" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.IntegrationTests/xunit.runner.json
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.IntegrationTests/xunit.runner.json
@@ -1,3 +1,3 @@
 {
-  "appDomain": "denied"
+  "shadowCopy": false
 }

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.csproj
@@ -25,9 +25,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="7.10.6072" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="8.0.50728" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.36" />
-    <PackageReference Include="xunit.assert" Version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Legacy.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="EnvDTE" Version="8.0.1" PrivateAssets="all" />
     <PackageReference Include="EnvDTE80" Version="8.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="compile" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="7.10.6072" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.8.0" Version="8.0.50728" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.1.36" />

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeTestAssemblyRunner.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeTestAssemblyRunner.cs
@@ -306,11 +306,11 @@ namespace Xunit.Harness
                         }
                         else if (testCase is IdeTestCase ideTestCase)
                         {
-                            return new IdeTestCase(this, ideTestCase.DefaultMethodDisplay, ideTestCase.TestMethod, ideTestCase.VisualStudioVersion, ideTestCase.TestMethodArguments);
+                            return new IdeTestCase(this, ideTestCase.DefaultMethodDisplay, ideTestCase.DefaultMethodDisplayOptions, ideTestCase.TestMethod, ideTestCase.VisualStudioVersion, ideTestCase.TestMethodArguments);
                         }
                         else
                         {
-                            return new XunitTestCase(this, TestMethodDisplay.ClassAndMethod, testCase.TestMethod, testCase.TestMethodArguments);
+                            return new XunitTestCase(this, TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testCase.TestMethod, testCase.TestMethodArguments);
                         }
                     });
 

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/InProcessIdeTestAssemblyRunner.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/InProcessIdeTestAssemblyRunner.cs
@@ -21,7 +21,7 @@ namespace Xunit.Harness
             {
                 if (testCase is IdeTestCase ideTestCase)
                 {
-                    return new IdeTestCase(diagnosticMessageSink, ideTestCase.DefaultMethodDisplay, ideTestCase.TestMethod, ideTestCase.VisualStudioVersion, ideTestCase.TestMethodArguments);
+                    return new IdeTestCase(diagnosticMessageSink, ideTestCase.DefaultMethodDisplay, ideTestCase.DefaultMethodDisplayOptions, ideTestCase.TestMethod, ideTestCase.VisualStudioVersion, ideTestCase.TestMethodArguments);
                 }
 
                 return testCase;

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeFactDiscoverer.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeFactDiscoverer.cs
@@ -6,7 +6,6 @@ namespace Xunit.Threading
     using System.Collections.Generic;
     using System.Linq;
     using Xunit.Abstractions;
-    using Xunit.Harness;
     using Xunit.Sdk;
 
     public class IdeFactDiscoverer : IXunitTestCaseDiscoverer
@@ -27,17 +26,17 @@ namespace Xunit.Threading
                     var testCases = new List<IXunitTestCase>();
                     foreach (var supportedVersion in GetSupportedVersions(factAttribute))
                     {
-                        yield return new IdeTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, supportedVersion);
+                        yield return new IdeTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedVersion);
                     }
                 }
                 else
                 {
-                    yield return new ExecutionErrorTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[IdeFact] methods are not allowed to be generic.");
+                    yield return new ExecutionErrorTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, "[IdeFact] methods are not allowed to be generic.");
                 }
             }
             else
             {
-                yield return new ExecutionErrorTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, "[IdeFact] methods are not allowed to have parameters. Did you mean to use [IdeTheory]?");
+                yield return new ExecutionErrorTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, "[IdeFact] methods are not allowed to have parameters. Did you mean to use [IdeTheory]?");
             }
         }
 

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCase.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCase.cs
@@ -9,7 +9,6 @@ namespace Xunit.Threading
     using System.Threading.Tasks;
     using Microsoft.Win32;
     using Xunit.Abstractions;
-    using Xunit.Harness;
     using Xunit.Sdk;
 
     public sealed class IdeTestCase : XunitTestCase
@@ -20,8 +19,8 @@ namespace Xunit.Threading
         {
         }
 
-        public IdeTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, ITestMethod testMethod, VisualStudioVersion visualStudioVersion, object[] testMethodArguments = null)
-            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+        public IdeTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, VisualStudioVersion visualStudioVersion, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
             SharedData = WpfTestSharedData.Instance;
             VisualStudioVersion = visualStudioVersion;
@@ -39,6 +38,8 @@ namespace Xunit.Threading
         }
 
         public new TestMethodDisplay DefaultMethodDisplay => base.DefaultMethodDisplay;
+
+        public new TestMethodDisplayOptions DefaultMethodDisplayOptions => base.DefaultMethodDisplayOptions;
 
         public WpfTestSharedData SharedData
         {

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk" Version="17.0.0-previews-1-31310-052" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="compile" />
     <PackageReference Include="xunit.assert" Version="2.3.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Sdk" Version="17.0.0-previews-1-31310-052" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="compile" />
-    <PackageReference Include="xunit.assert" Version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Dev11/Microsoft.VisualStudio.IntegrationTestService.Dev11.csproj
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Dev11/Microsoft.VisualStudio.IntegrationTestService.Dev11.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.1.192" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038" PrivateAssets="all" />
     <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.2155-preview2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Sdk" Version="17.0.0-previews-1-31310-052" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
* Update Microsoft.VSSDK.BuildTools to allow building in Visual Studio 2022
* Update xunit to 2.4.1, and update documentation to match

Closes #3
Supersedes #31