### PR TITLE
Remove secure IPC channel requirement

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstance.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstance.cs
@@ -52,7 +52,7 @@ namespace Xunit.Harness
                 new BinaryClientFormatterSinkProvider(),
                 new BinaryServerFormatterSinkProvider { TypeFilterLevel = TypeFilterLevel.Full });
 
-            ChannelServices.RegisterChannel(_integrationServiceChannel, ensureSecurity: true);
+            ChannelServices.RegisterChannel(_integrationServiceChannel, ensureSecurity: false);
 
             // Connect to a 'well defined, shouldn't conflict' IPC channel
             _integrationService = IntegrationService.GetInstanceFromHostProcess(hostProcess);

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Shared/IntegrationTestServiceCommands.cs
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Shared/IntegrationTestServiceCommands.cs
@@ -118,6 +118,7 @@ namespace Microsoft.VisualStudio.IntegrationTestService
                     _serviceChannel = null;
                 }
 
+                GC.KeepAlive(_marshalledService);
                 _marshalledService = null;
                 _service = null;
 

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Shared/IntegrationTestServiceCommands.cs
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Shared/IntegrationTestServiceCommands.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.IntegrationTestService
                 _marshalledService = RemotingServices.Marshal(_service, serviceType.FullName, serviceType);
 
                 _serviceChannel.StartListening(null);
-                ChannelServices.RegisterChannel(_serviceChannel, ensureSecurity: true);
+                ChannelServices.RegisterChannel(_serviceChannel, ensureSecurity: false);
 
                 SwapAvailableCommands(_startMenuCmd, _stopMenuCmd);
             }


### PR DESCRIPTION
Fixes failures to run integration tests from Test Explorer.