### PR TITLE
Support experimental extensions

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstanceFactory.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstanceFactory.cs
@@ -326,7 +326,7 @@ namespace Xunit.Harness
             var vsExeFile = Path.Combine(installationPath, @"Common7\IDE\devenv.exe");
             var vsRegEditExeFile = Path.Combine(installationPath, @"Common7\IDE\VsRegEdit.exe");
 
-            var temporaryFolder = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var temporaryFolder = Path.Combine(Path.GetTempPath(), "vs-extension-testing", Path.GetRandomFileName());
             Assert.False(Directory.Exists(temporaryFolder));
             Directory.CreateDirectory(temporaryFolder);
 

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstanceFactory.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstanceFactory.cs
@@ -10,6 +10,7 @@ namespace Xunit.Harness
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Text;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.Setup.Configuration;
     using Microsoft.Win32;
@@ -136,7 +137,7 @@ namespace Xunit.Harness
                 installationPath = instance.Item1;
                 actualVersion = instance.Item2;
 
-                hostProcess = StartNewVisualStudioProcess(installationPath, version, extensionFiles);
+                hostProcess = await StartNewVisualStudioProcessAsync(installationPath, version, extensionFiles).ConfigureAwait(true);
 
                 // We wait until the DTE instance is up before we're good
                 dte = await IntegrationHelper.WaitForNotNullAsync(() => IntegrationHelper.TryLocateDteForProcess(hostProcess)).ConfigureAwait(true);
@@ -320,7 +321,7 @@ namespace Xunit.Harness
                                 "There were no instances of Visual Studio found that match the specified requirements.");
         }
 
-        private static Process StartNewVisualStudioProcess(string installationPath, Version version, ImmutableList<string> extensionFiles)
+        private static async Task<Process> StartNewVisualStudioProcessAsync(string installationPath, Version version, ImmutableList<string> extensionFiles)
         {
             var vsExeFile = Path.Combine(installationPath, @"Common7\IDE\devenv.exe");
             var vsRegEditExeFile = Path.Combine(installationPath, @"Common7\IDE\VsRegEdit.exe");
@@ -342,7 +343,28 @@ namespace Xunit.Harness
                     rootSuffix,
                     $"\"{installationPath}\"",
                     string.Join(" ", extensions.Select(extension => $"\"{extension}\"")));
-                Process.Start(CreateSilentStartInfo(installerAssemblyPath, arguments)).WaitForExit();
+
+                var installProcessStartInfo = CreateSilentStartInfo(installerAssemblyPath, arguments);
+                installProcessStartInfo.RedirectStandardError = true;
+                installProcessStartInfo.RedirectStandardOutput = true;
+                using var installProcess = Process.Start(installProcessStartInfo);
+                var standardErrorAsync = installProcess.StandardError.ReadToEndAsync();
+                var standardOutputAsync = installProcess.StandardOutput.ReadToEndAsync();
+                installProcess.WaitForExit();
+
+                if (installProcess.ExitCode != 0)
+                {
+                    var messageBuilder = new StringBuilder();
+                    messageBuilder.AppendLine($"VSIX installer failed with exit code: {installProcess.ExitCode}");
+                    messageBuilder.AppendLine();
+                    messageBuilder.AppendLine($"Standard Error:");
+                    messageBuilder.AppendLine(await standardErrorAsync.ConfigureAwait(true));
+                    messageBuilder.AppendLine();
+                    messageBuilder.AppendLine($"Standard Output:");
+                    messageBuilder.AppendLine(await standardOutputAsync.ConfigureAwait(true));
+
+                    throw new InvalidOperationException(messageBuilder.ToString());
+                }
             }
             finally
             {

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared.projitems
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)InProcess\VisualStudio_InProc.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OutOfProcess\OutOfProcComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OutOfProcess\TestInvoker_OutOfProc.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Threading\ErrorReportingIdeTestRunner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\ExceptionUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\IdeFactDiscoverer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\IdeTestCase.cs" />

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/ErrorReportingIdeTestRunner.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/ErrorReportingIdeTestRunner.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for more information.
+
+namespace Xunit.Threading
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit.Abstractions;
+    using Xunit.Sdk;
+
+    public class ErrorReportingIdeTestRunner : XunitTestRunner
+    {
+        private readonly Exception _exception;
+
+        public ErrorReportingIdeTestRunner(Exception exception, ITest test, IMessageBus messageBus, Type testClass, object[] constructorArguments, MethodInfo testMethod, object[] testMethodArguments, string skipReason, IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            : base(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource)
+        {
+            _exception = exception;
+        }
+
+        protected override Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator)
+        {
+            return aggregator.RunAsync(
+                () =>
+                {
+                    var tcs = new TaskCompletionSource<decimal>();
+                    tcs.SetException(_exception);
+                    return tcs.Task;
+                });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCase.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCase.cs
@@ -83,8 +83,8 @@ namespace Xunit.Threading
 
         public override void Deserialize(IXunitSerializationInfo data)
         {
-            base.Deserialize(data);
             VisualStudioVersion = (VisualStudioVersion)data.GetValue<int>(nameof(VisualStudioVersion));
+            base.Deserialize(data);
             SkipReason = data.GetValue<string>(nameof(SkipReason));
             SharedData = WpfTestSharedData.Instance;
         }

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseRunner.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseRunner.cs
@@ -49,6 +49,10 @@ namespace Xunit.Threading
                 // TODO: Verify version under test
                 return new InProcessIdeTestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource);
             }
+            else if (SharedData.Exception is not null)
+            {
+                return new ErrorReportingIdeTestRunner(SharedData.Exception, test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource);
+            }
             else
             {
                 throw new NotSupportedException($"{nameof(IdeFactAttribute)} can only be used with the {nameof(IdeTestFramework)} test framework");

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/WpfTestSharedData.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/WpfTestSharedData.cs
@@ -37,5 +37,7 @@ namespace Xunit.Threading
         }
 
         public Semaphore TestSerializationGate => _testSerializationGate;
+
+        public Exception Exception { get; set; }
     }
 }

--- a/src/Microsoft.VisualStudio.VsixInstaller.11/Microsoft.VisualStudio.VsixInstaller.11.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.11/Microsoft.VisualStudio.VsixInstaller.11.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Platforms>x86</Platforms>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);DEV11</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.VsixInstaller.12/Microsoft.VisualStudio.VsixInstaller.12.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.12/Microsoft.VisualStudio.VsixInstaller.12.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Platforms>x86</Platforms>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);DEV12</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.VsixInstaller.14/Microsoft.VisualStudio.VsixInstaller.14.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.14/Microsoft.VisualStudio.VsixInstaller.14.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Platforms>x86</Platforms>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);DEV14</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.VsixInstaller.15/Microsoft.VisualStudio.VsixInstaller.15.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.15/Microsoft.VisualStudio.VsixInstaller.15.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Platforms>x86</Platforms>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);DEV15</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.VsixInstaller.16/Microsoft.VisualStudio.VsixInstaller.16.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.16/Microsoft.VisualStudio.VsixInstaller.16.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <Platforms>x86</Platforms>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);DEV16</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
@@ -9,6 +9,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <NoWarn>$(NoWarn);MSB3270</NoWarn>
     <IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);DEV17</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.VsixInstaller.Shared/Installer.cs
+++ b/src/Microsoft.VisualStudio.VsixInstaller.Shared/Installer.cs
@@ -77,6 +77,18 @@ namespace Microsoft.VisualStudio.VsixInstaller
                 {
                     if (extensionManager.IsInstalled(extension))
                     {
+#if !(DEV11 || DEV12)
+                        if (extension.Header.IsExperimental
+                            && extensionManager.TryGetInstalledExtension(extension.Header.Identifier, out var installedExtension)
+                            && !installedExtension.Header.IsExperimental
+                            && installedExtension.InstalledPerMachine)
+                        {
+                            // Experimental extensions can be installed to the per-user folder without removing the
+                            // non-experimental extension from a machine location.
+                            continue;
+                        }
+#endif
+
                         extensionManager.Uninstall(extensionManager.GetInstalledExtension(extension.Header.Identifier));
                     }
                 }


### PR DESCRIPTION
* Fix failure to report skipped tests when a harness failure affected a non-skipped test
* Fix failure to report the correct display name for skipped tests (showed Unspecified instead of a specific version)
* Fix failure to report errors for VsixInstaller
* Extract VsixInstaller to a common temporary folder that can be easily deleted
* Update VsixInstaller to support experimental extensions

Here's a screenshot showing Test Explorer when a VS2019 extension fails to install and earlier versions are not installed. The specific error shown was subsequently fixed by e18a126.

![image](https://user-images.githubusercontent.com/1408396/126811358-a0dce904-1d79-4cb3-8469-6122069fe6b2.png)
