### PR TITLE
Disable EqualExceptionLegacy in internal CI

### DIFF
--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -37,7 +37,7 @@ steps:
 - powershell: test/EqualExceptionLegacy/Test.ps1 -binlog "$(Build.ArtifactStagingDirectory)/build_logs/EqualExceptionLegacy.binlog"
   failOnStderr: false
   displayName: Test EqualExceptionLegacy
-  condition: succeededOrFailed()
+  condition: eq(variables['SignTypeSelection'], '')
 
 - powershell: azure-pipelines/variables/_pipelines.ps1
   failOnStderr: true


### PR DESCRIPTION
Avoids NuGet errors from trying to restore from an untrusted root (directly from build output).