### PR TITLE
Fix .editorconfig configuration for csharp_indent_switch_labels

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -128,7 +128,7 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
-csharp_indent_switch_labels = true
+csharp_indent_switch_labels = false
 csharp_indent_labels = flush_left
 
 # Prefer "var" everywhere


### PR DESCRIPTION
This configuration was unintentionally mismatched with the code formatting used in this repository, which led to some code churn in pull requests. This change updates **.editorconfig** to match the expected code style.