### PR TITLE
Add IdeSettingsAttribute for setting properties on test classes

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/IdeFactAttribute.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/IdeFactAttribute.cs
@@ -12,8 +12,8 @@ namespace Xunit
     {
         public IdeFactAttribute()
         {
-            MinVersion = VisualStudioVersion.VS2012;
-            MaxVersion = VisualStudioVersion.VS2022;
+            MinVersion = VisualStudioVersion.Unspecified;
+            MaxVersion = VisualStudioVersion.Unspecified;
         }
 
         public VisualStudioVersion MinVersion

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/IdeSettingsAttribute.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/IdeSettingsAttribute.cs
@@ -4,13 +4,11 @@
 namespace Xunit
 {
     using System;
-    using Xunit.Sdk;
 
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    [XunitTestCaseDiscoverer("Xunit.Threading.IdeTheoryDiscoverer", "Microsoft.VisualStudio.Extensibility.Testing.Xunit")]
-    public class IdeTheoryAttribute : TheoryAttribute, IIdeSettingsAttribute
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class IdeSettingsAttribute : Attribute, IIdeSettingsAttribute
     {
-        public IdeTheoryAttribute()
+        public IdeSettingsAttribute()
         {
             MinVersion = VisualStudioVersion.Unspecified;
             MaxVersion = VisualStudioVersion.Unspecified;

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared.projitems
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Harness\VSConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Harness\WellKnownCommandNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IdeFactAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IdeSettingsAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IdeTheoryAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IIdeSettingsAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InProcess\InProcComponent.cs" />

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTheoryDiscoverer.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTheoryDiscoverer.cs
@@ -16,7 +16,7 @@ namespace Xunit.Threading
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkip(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, string skipReason)
         {
-            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(theoryAttribute))
+            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(testMethod, theoryAttribute))
             {
                 yield return new IdeTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedVersion);
             }
@@ -24,7 +24,7 @@ namespace Xunit.Threading
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForSkippedDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow, string skipReason)
         {
-            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(theoryAttribute))
+            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(testMethod, theoryAttribute))
             {
                 yield return new IdeSkippedDataRowTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedVersion, skipReason, dataRow);
             }
@@ -32,7 +32,7 @@ namespace Xunit.Threading
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
         {
-            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(theoryAttribute))
+            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(testMethod, theoryAttribute))
             {
                 yield return new IdeTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedVersion, dataRow);
             }
@@ -40,7 +40,7 @@ namespace Xunit.Threading
 
         protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
-            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(theoryAttribute))
+            foreach (var supportedVersion in IdeFactDiscoverer.GetSupportedVersions(testMethod, theoryAttribute))
             {
                 yield return new IdeTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedVersion);
             }


### PR DESCRIPTION
Previously, customizing the value of an `IdeFact` property required setting the property on every individual test. With this change, settings can be configured for entire types by applying the `[IdeSettings]` attribute to the type (or to a base type). Explicit values in the `[IdeFact]` attribute take precedence over `[IdeSettings]` values.

This change avoids the need to set the `MinVersion` and `MaxVersion` on each individual test ([Example](https://github.com/dotnet/roslyn-sdk/blob/ccc0973f6bad2782222d0a6224ba46fe73799920/tests/VisualStudio.Roslyn.SDK/Roslyn.SDK.IntegrationTests/CreateProjectTests.cs#L25)). The `[IdeSettings(MinVersion = ..., MaxVersion = ...)]` would instead be set on the abstract base class, and automatically apply to all derived tests marked with `[IdeFact]`.