### PR TITLE
Collect IDE state at point of failure

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/DataCollectionService.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/DataCollectionService.cs
@@ -118,6 +118,7 @@ namespace Xunit.Harness
                 ActivityLogCollector.TryWriteActivityLogToFile(CreateLogFileName(logDir, timestamp, testName, errorId, "Activity", "xml"));
                 EventLogCollector.TryWriteDotNetEntriesToFile(CreateLogFileName(logDir, timestamp, testName, errorId, "DotNet", "log"));
                 EventLogCollector.TryWriteWatsonEntriesToFile(CreateLogFileName(logDir, timestamp, testName, errorId, "Watson", "log"));
+                IdeStateCollector.TryWriteIdeStateToFile(CreateLogFileName(logDir, timestamp, testName, errorId, "IDE", "log"));
 
                 ScreenshotService.TakeScreenshot(CreateLogFileName(logDir, timestamp, testName, errorId, string.Empty, $"png"));
             }

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeStateCollector.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeStateCollector.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for more information.
+
+namespace Xunit.Harness
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Xunit.InProcess;
+
+    internal static class IdeStateCollector
+    {
+        internal static void TryWriteIdeStateToFile(string filePath)
+        {
+            try
+            {
+                var content = VisualStudio_InProc.GetIdeState();
+                if (string.IsNullOrEmpty(content))
+                {
+                    return;
+                }
+
+                File.WriteAllText(filePath, content, Encoding.UTF8);
+            }
+            catch (Exception ex)
+            {
+                File.WriteAllText(filePath, ex.ToString(), Encoding.UTF8);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared.projitems
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Harness\FeedbackItemDotNetEntry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Harness\FeedbackItemWatsonEntry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Harness\GlobalServiceProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Harness\IdeStateCollector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Harness\IdeTestAssemblyRunner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Harness\IdeTestFramework.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Harness\IdeTestFrameworkExecutor.cs" />

--- a/test/EqualExceptionLegacy/Test.ps1
+++ b/test/EqualExceptionLegacy/Test.ps1
@@ -95,6 +95,13 @@ function Verify-HasLogs([string]$shortTestName, [string]$exceptionName) {
         $currentFailureCount++
     }
 
+    $ideLogPath = Get-ChildItem "$CurrentTestResultsDir\Screenshots\??.??.??-$shortTestName-$exceptionName.IDE.log" | sort LastWriteTime | select -last 1
+    if (-not $ideLogPath) {
+        Write-Host "Verifying IDE state logs for failing test"
+        Write-Host "Missing log file '$shortTestName-$exceptionName.IDE.log'"
+        $currentFailureCount++
+    }
+
     $pngPath = Get-ChildItem "$CurrentTestResultsDir\Screenshots\??.??.??-$shortTestName-$exceptionName.png" | sort LastWriteTime | select -last 1
     if (-not $pngPath) {
         Write-Host "Verifying diagnostic screenshot for failing test"


### PR DESCRIPTION
This is the first part of collecting a log describing the IDE state at the point of test failure. Only a limited amount of information is collected at this time:

* The currently open solution
* The text of items shown in the error list

The information can be readily expanded in the future to simplify diagnostics.