### PR TITLE
Avoid discovering duplicate instance test cases

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeFactDiscoverer.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeFactDiscoverer.cs
@@ -28,7 +28,10 @@ namespace Xunit.Threading
                     foreach (var supportedInstance in GetSupportedInstances(testMethod, factAttribute))
                     {
                         yield return new IdeTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedInstance);
-                        yield return new IdeInstanceTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), CreateVisualStudioTestMethod(supportedInstance), supportedInstance);
+                        if (IdeInstanceTestCase.TryCreateNewInstanceForFramework(discoveryOptions, _diagnosticMessageSink, supportedInstance) is { } instanceTestCase)
+                        {
+                            yield return instanceTestCase;
+                        }
                     }
                 }
                 else

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeInstanceTestCase.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeInstanceTestCase.cs
@@ -4,7 +4,9 @@
 namespace Xunit.Threading
 {
     using System;
+    using System.Collections.Immutable;
     using System.ComponentModel;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Xunit.Abstractions;
@@ -13,6 +15,14 @@ namespace Xunit.Threading
 
     public sealed class IdeInstanceTestCase : IdeTestCaseBase
     {
+        /// <summary>
+        /// Keep track of unique <see cref="IdeInstanceTestCase"/> instances returned for a given discovery pass. The
+        /// <see cref="ITestFrameworkDiscoveryOptions"/> instance used for discovery is assumed to be a singleton
+        /// instance used for one complete discovery pass. If this instance is used for subsequent discovery passes,
+        /// the instance test cases might not show up in the discovery.
+        /// </summary>
+        private static readonly ConditionalWeakTable<ITestFrameworkDiscoveryOptions, StrongBox<ImmutableDictionary<VisualStudioInstanceKey, IdeInstanceTestCase>>> _instances = new();
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Called by the deserializer; should only be called by deriving classes for deserialization purposes", error: true)]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -24,6 +34,20 @@ namespace Xunit.Threading
         public IdeInstanceTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, VisualStudioInstanceKey visualStudioInstanceKey, object?[]? testMethodArguments = null)
             : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, visualStudioInstanceKey, testMethodArguments)
         {
+        }
+
+        public static IdeInstanceTestCase? TryCreateNewInstanceForFramework(ITestFrameworkDiscoveryOptions discoveryOptions, IMessageSink diagnosticMessageSink, VisualStudioInstanceKey visualStudioInstanceKey)
+        {
+            var lazyInstances = _instances.GetValue(discoveryOptions, static _ => new StrongBox<ImmutableDictionary<VisualStudioInstanceKey, IdeInstanceTestCase>>(ImmutableDictionary<VisualStudioInstanceKey, IdeInstanceTestCase>.Empty));
+            var candidateTestCase = new IdeInstanceTestCase(diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), IdeFactDiscoverer.CreateVisualStudioTestMethod(visualStudioInstanceKey), visualStudioInstanceKey);
+            var testCase = ImmutableInterlocked.GetOrAdd(ref lazyInstances.Value, visualStudioInstanceKey, candidateTestCase);
+            if (testCase != candidateTestCase)
+            {
+                // A different call to this method already returned the test case for this instance
+                return null;
+            }
+
+            return candidateTestCase;
         }
 
         public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseBase.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseBase.cs
@@ -56,7 +56,14 @@ namespace Xunit.Threading
 
         protected override string GetUniqueID()
         {
-            return $"{base.GetUniqueID()}_{VisualStudioInstanceKey.Version}";
+            if (string.IsNullOrEmpty(VisualStudioInstanceKey.RootSuffix))
+            {
+                return $"{base.GetUniqueID()}_{VisualStudioInstanceKey.Version}";
+            }
+            else
+            {
+                return $"{base.GetUniqueID()}_{VisualStudioInstanceKey.RootSuffix}_{VisualStudioInstanceKey.Version}";
+            }
         }
 
         public override void Serialize(IXunitSerializationInfo data)

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTheoryDiscoverer.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTheoryDiscoverer.cs
@@ -19,7 +19,10 @@ namespace Xunit.Threading
             foreach (var supportedInstance in IdeFactDiscoverer.GetSupportedInstances(testMethod, theoryAttribute))
             {
                 yield return new IdeTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedInstance);
-                yield return new IdeInstanceTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), IdeFactDiscoverer.CreateVisualStudioTestMethod(supportedInstance), supportedInstance);
+                if (IdeInstanceTestCase.TryCreateNewInstanceForFramework(discoveryOptions, DiagnosticMessageSink, supportedInstance) is { } instanceTestCase)
+                {
+                    yield return instanceTestCase;
+                }
             }
         }
 
@@ -36,7 +39,10 @@ namespace Xunit.Threading
             foreach (var supportedInstance in IdeFactDiscoverer.GetSupportedInstances(testMethod, theoryAttribute))
             {
                 yield return new IdeTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedInstance, dataRow);
-                yield return new IdeInstanceTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), IdeFactDiscoverer.CreateVisualStudioTestMethod(supportedInstance), supportedInstance);
+                if (IdeInstanceTestCase.TryCreateNewInstanceForFramework(discoveryOptions, DiagnosticMessageSink, supportedInstance) is { } instanceTestCase)
+                {
+                    yield return instanceTestCase;
+                }
             }
         }
 
@@ -45,7 +51,10 @@ namespace Xunit.Threading
             foreach (var supportedInstance in IdeFactDiscoverer.GetSupportedInstances(testMethod, theoryAttribute))
             {
                 yield return new IdeTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, supportedInstance);
-                yield return new IdeInstanceTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), IdeFactDiscoverer.CreateVisualStudioTestMethod(supportedInstance), supportedInstance);
+                if (IdeInstanceTestCase.TryCreateNewInstanceForFramework(discoveryOptions, DiagnosticMessageSink, supportedInstance) is { } instanceTestCase)
+                {
+                    yield return instanceTestCase;
+                }
             }
         }
     }


### PR DESCRIPTION
Avoids messages like the following appearing in test logs:

```
[xUnit.net 00:00:01.53] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.53] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.53] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.53] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
[xUnit.net 00:00:01.54] Microsoft.VisualStudio.Extensibility.Testing.Xunit: Skipping test case with duplicate ID '7e9e96345a4050adf1b52a8695d4d7a6d8101c1f_VS2022' ('Xunit.Instances.VisualStudio (VS2022)' and 'Xunit.Instances.VisualStudio (VS2022)')
```