### PR TITLE
Avoid leaving instances of VS open after test runs

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeInstanceTestCase.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeInstanceTestCase.cs
@@ -36,6 +36,8 @@ namespace Xunit.Threading
         {
         }
 
+        protected override bool IncludeRootSuffixInDisplayName => true;
+
         public static IdeInstanceTestCase? TryCreateNewInstanceForFramework(ITestFrameworkDiscoveryOptions discoveryOptions, IMessageSink diagnosticMessageSink, VisualStudioInstanceKey visualStudioInstanceKey)
         {
             var lazyInstances = _instances.GetValue(discoveryOptions, static _ => new StrongBox<ImmutableDictionary<VisualStudioInstanceKey, IdeInstanceTestCase>>(ImmutableDictionary<VisualStudioInstanceKey, IdeInstanceTestCase>.Empty));

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseBase.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseBase.cs
@@ -48,10 +48,19 @@ namespace Xunit.Threading
             private set;
         }
 
+        protected virtual bool IncludeRootSuffixInDisplayName => false;
+
         protected override string GetDisplayName(IAttributeInfo factAttribute, string displayName)
         {
             var baseName = base.GetDisplayName(factAttribute, displayName);
-            return $"{baseName} ({VisualStudioInstanceKey.Version})";
+            if (!IncludeRootSuffixInDisplayName || string.IsNullOrEmpty(VisualStudioInstanceKey.RootSuffix))
+            {
+                return $"{baseName} ({VisualStudioInstanceKey.Version})";
+            }
+            else
+            {
+                return $"{baseName} ({VisualStudioInstanceKey.Version}, {VisualStudioInstanceKey.RootSuffix})";
+            }
         }
 
         protected override string GetUniqueID()

--- a/test/EqualExceptionLegacy/Test.ps1
+++ b/test/EqualExceptionLegacy/Test.ps1
@@ -127,9 +127,9 @@ if ($trx.TestRun.ResultSummary.outcome -ne "Failed") {
     $errorCount++
 }
 
-if ($trx.TestRun.ResultSummary.Counters.executed -ne "12") {
+if ($trx.TestRun.ResultSummary.Counters.executed -ne "16") {
     Write-Host "Testing /TestRun/ResultSummary/Counters/@executed"
-    Write-Host "Expected '12', found '$($trx.TestRun.ResultSummary.Counters.executed)'"
+    Write-Host "Expected '16', found '$($trx.TestRun.ResultSummary.Counters.executed)'"
     $errorCount++
 }
 
@@ -139,9 +139,9 @@ if ($trx.TestRun.ResultSummary.Counters.total -ne "75") {
     $errorCount++
 }
 
-if ($trx.TestRun.ResultSummary.Counters.passed -ne "4") {
+if ($trx.TestRun.ResultSummary.Counters.passed -ne "8") {
     Write-Host "Testing /TestRun/ResultSummary/Counters/@passed"
-    Write-Host "Expected '4', found '$($trx.TestRun.ResultSummary.Counters.passed)'"
+    Write-Host "Expected '8', found '$($trx.TestRun.ResultSummary.Counters.passed)'"
     $errorCount++
 }
 


### PR DESCRIPTION
* Make sure IdeInstanceTestCase runs after other tests
* Make sure all test collections are considered before running remaining IdeInstanceTestCase
* Report skipped IdeInstanceTestCase as passed instead of not run