### PR TITLE
Do not copy dependencies to VsixInstaller output directories

### DIFF
--- a/src/Microsoft.VisualStudio.VsixInstaller.11/Microsoft.VisualStudio.VsixInstaller.11.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.11/Microsoft.VisualStudio.VsixInstaller.11.csproj
@@ -10,6 +10,15 @@
     <DefineConstants>$(DefineConstants);DEV11</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Avoid copying dependencies to the output directory. This executable uses a custom AssemblyResolve handler to load
+      the correct dependencies from the target installation directory, and we don't want files in the current directory
+      to override this behavior.
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ExtensionManager" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\11\Microsoft.VisualStudio.ExtensionManager.dll" Private="false" />
     <Reference Include="Microsoft.VisualStudio.ExtensionManager.Implementation" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\11\Microsoft.VisualStudio.ExtensionManager.Implementation.dll" Private="false" />

--- a/src/Microsoft.VisualStudio.VsixInstaller.12/Microsoft.VisualStudio.VsixInstaller.12.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.12/Microsoft.VisualStudio.VsixInstaller.12.csproj
@@ -10,6 +10,15 @@
     <DefineConstants>$(DefineConstants);DEV12</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Avoid copying dependencies to the output directory. This executable uses a custom AssemblyResolve handler to load
+      the correct dependencies from the target installation directory, and we don't want files in the current directory
+      to override this behavior.
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ExtensionManager" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\12\Microsoft.VisualStudio.ExtensionManager.dll" Private="false" />
     <Reference Include="Microsoft.VisualStudio.ExtensionManager.Implementation" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\12\Microsoft.VisualStudio.ExtensionManager.Implementation.dll" Private="false" />

--- a/src/Microsoft.VisualStudio.VsixInstaller.14/Microsoft.VisualStudio.VsixInstaller.14.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.14/Microsoft.VisualStudio.VsixInstaller.14.csproj
@@ -10,6 +10,15 @@
     <DefineConstants>$(DefineConstants);DEV14</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Avoid copying dependencies to the output directory. This executable uses a custom AssemblyResolve handler to load
+      the correct dependencies from the target installation directory, and we don't want files in the current directory
+      to override this behavior.
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ExtensionManager" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\14\Microsoft.VisualStudio.ExtensionManager.dll" Private="false" />
     <Reference Include="Microsoft.VisualStudio.ExtensionManager.Implementation" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\14\Microsoft.VisualStudio.ExtensionManager.Implementation.dll" Private="false" />

--- a/src/Microsoft.VisualStudio.VsixInstaller.15/Microsoft.VisualStudio.VsixInstaller.15.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.15/Microsoft.VisualStudio.VsixInstaller.15.csproj
@@ -10,6 +10,15 @@
     <DefineConstants>$(DefineConstants);DEV15</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Avoid copying dependencies to the output directory. This executable uses a custom AssemblyResolve handler to load
+      the correct dependencies from the target installation directory, and we don't want files in the current directory
+      to override this behavior.
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ExtensionEngine" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\15\Microsoft.VisualStudio.ExtensionEngine.dll" Private="false" />
     <Reference Include="Microsoft.VisualStudio.ExtensionManager" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\15\Microsoft.VisualStudio.ExtensionManager.dll" Private="false" />

--- a/src/Microsoft.VisualStudio.VsixInstaller.16/Microsoft.VisualStudio.VsixInstaller.16.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.16/Microsoft.VisualStudio.VsixInstaller.16.csproj
@@ -10,6 +10,15 @@
     <DefineConstants>$(DefineConstants);DEV16</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Avoid copying dependencies to the output directory. This executable uses a custom AssemblyResolve handler to load
+      the correct dependencies from the target installation directory, and we don't want files in the current directory
+      to override this behavior.
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ExtensionEngine" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\16\Microsoft.VisualStudio.ExtensionEngine.dll" Private="false" />
     <Reference Include="Microsoft.VisualStudio.ExtensionManager" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\16\Microsoft.VisualStudio.ExtensionManager.dll" Private="false" />

--- a/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
@@ -13,6 +13,15 @@
     <DefineConstants>$(DefineConstants);DEV17</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Avoid copying dependencies to the output directory. This executable uses a custom AssemblyResolve handler to load
+      the correct dependencies from the target installation directory, and we don't want files in the current directory
+      to override this behavior.
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ExtensionEngine" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\17\Microsoft.VisualStudio.ExtensionEngine.dll" Private="false" />
     <Reference Include="Microsoft.VisualStudio.ExtensionManager" HintPath="$(PkgMicrosoft_VisualStudio_Extensibility_Testing_SupportFiles)\build\ref\17\Microsoft.VisualStudio.ExtensionManager.dll" Private="false" />


### PR DESCRIPTION
This executable uses a custom `AssemblyResolve` handler to load the correct dependencies from the target installation directory, and we don't want files in the current directory to override this behavior.

This change doesn't impact deployment, but may simplify local debugging scenarios.