### PR TITLE
Avoid references to Newtonsoft.Json prior to 13.0.1

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.UnitTests/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.UnitTests/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator.UnitTests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2-beta1.22269.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests/Microsoft.VisualStudio.Extensibility.Testing.Xunit.IntegrationTests.csproj
@@ -14,6 +14,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" PrivateAssets="all" />
+    <!--
+      A Newtonsoft.Json package reference with insecure defaults is inherited, but not needed by this project.
+      Override the reference to a secure version, but exclude it from the build and packaging.
+    -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" ExcludeAssets="all" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit/Microsoft.VisualStudio.Extensibility.Testing.Xunit.csproj
@@ -19,6 +19,11 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="compile" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.619-beta" PrivateAssets="all" />
+    <!--
+      A Newtonsoft.Json package reference with insecure defaults is inherited, but not needed by this project.
+      Override the reference to a secure version, but exclude it from the build and packaging.
+    -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" ExcludeAssets="all" PrivateAssets="all" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />

--- a/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
+++ b/src/Microsoft.VisualStudio.IntegrationTestService.Dev17/Microsoft.VisualStudio.IntegrationTestService.Dev17.csproj
@@ -31,6 +31,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.3177-preview3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" PrivateAssets="all" />
+    <!--
+      A Newtonsoft.Json package reference with insecure defaults is inherited, but not needed by this project.
+      Override the reference to a secure version, but exclude it from the build and packaging.
+    -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.VsixInstaller.16/Microsoft.VisualStudio.VsixInstaller.16.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.16/Microsoft.VisualStudio.VsixInstaller.16.csproj
@@ -29,7 +29,11 @@
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.SupportFiles" GeneratePathProperty="true" Version="1.1.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="16.0.28729" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.8.55" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <!--
+      A Newtonsoft.Json package reference with insecure defaults is inherited, but not needed by this project.
+      Override the reference to a secure version, but exclude it from the build and packaging.
+    -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" ExcludeAssets="all" PrivateAssets="all" />
     <PackageReference Include="StreamJsonRpc" Version="2.7.67" />
   </ItemGroup>
 

--- a/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
+++ b/src/Microsoft.VisualStudio.VsixInstaller.17/Microsoft.VisualStudio.VsixInstaller.17.csproj
@@ -32,6 +32,11 @@
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Testing.SupportFiles" GeneratePathProperty="true" Version="1.1.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-3-31605-261" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="17.0.0-previews-3-31605-261" />
+    <!--
+      A Newtonsoft.Json package reference with insecure defaults is inherited, but not needed by this project.
+      Override the reference to a secure version, but exclude it from the build and packaging.
+    -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="..\Microsoft.VisualStudio.VsixInstaller.Shared\Microsoft.VisualStudio.VsixInstaller.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
Some downstream applications may provide builds of Newtonsoft.Json which do not adhere to component governance guidelines, but those components are outside the scope of this repository.