### PR TITLE
Revert "Revert "Take periodic screenshots of devenv.exe to help with diagnosing timeouts""

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstanceFactory.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/VisualStudioInstanceFactory.cs
@@ -408,6 +408,10 @@ namespace Xunit.Harness
             IntegrationHelper.KillProcess("dexplore");
 
             var process = Process.Start(CreateStartInfo(vsExeFile, silent: false, vsLaunchArgs));
+
+            // Run the snapshot collection operation, but don't block on its completion for the actual test execution
+            _ = Task.Run(() => TakeSnapshotEveryTimeSpanUntilProcessExit(process, $"devenv{process.Id}"));
+
             Debug.WriteLine($"Launched a new instance of Visual Studio. (ID: {process.Id})");
 
             return process;


### PR DESCRIPTION
Reverts microsoft/vs-extension-testing#142

Restores the screenshots feature which was added in #138. The underlying cause of the delays in dotnet/roslyn-sdk#1052 was a failure to add **XUnitAssemblyInfo.cs** to set the `CollectionBehavior.CollectionPerAssembly` behavior.