### PR TITLE
Update NuGet feed to use msft_consumption

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,8 +9,7 @@
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="msft_consumption" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
   </packageSources>
   <trustedSigners>
     <repository name="dotnet-public" serviceIndex="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json">


### PR DESCRIPTION
This change is needed because the team owning these repositories opted to replace them (all downstream consumers are broken) instead of renaming them and placing the new feed at the same address (all downstream consumers would work without alteration).