### PR TITLE
Update Roslyn and GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,53 +59,53 @@ jobs:
       if: always()
     - name: 📢 Upload project.assets.json files
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: projectAssetsJson-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/projectAssetsJson
       continue-on-error: true
     - name: 📢 Upload variables
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: variables-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/Variables
       continue-on-error: true
     - name: 📢 Upload build_logs
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: build_logs-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/build_logs
       continue-on-error: true
     - name: 📢 Upload testResults
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: testResults-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/testResults
       continue-on-error: true
     - name: 📢 Upload rawTestResults
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: rawTestResults-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/rawTestResults
       continue-on-error: true
     - name: 📢 Upload coverageResults
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: coverageResults-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/coverageResults
       continue-on-error: true
     - name: 📢 Upload symbols
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: symbols-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/symbols
       continue-on-error: true
     - name: 📢 Upload deployables
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: deployables-${{ runner.os }}
         path: ${{ runner.temp }}/_artifacts/deployables

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,8 +42,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.12.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -19,6 +19,7 @@
       <owners>Microsoft;xunit;manuel.roemer;sharwell;jamesnk;aarnott;MarcoRossignoli;Thecentury;mmanela;onovotny</owners>
       <certificate fingerprint="0e5f38f57dc1bcc806d8494f4f90fbcedd988b46760709cbeec6f4219aa6157d" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="5a2901d6ada3d18260b9c6dfe2133c95d74b9eef6ae0e5dc334c8454d1477df4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
     </repository>
     <author name="Microsoft">
       <certificate fingerprint="aa12da22a49bce7d5c1ae64cc1f3d892f150da76140f210abd2cbffca2c18a27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.410",
+    "version": "6.0.100",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "8.0.406",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "9.0.200",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.406",
+    "version": "7.0.410",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator/TestServicesSourceGenerator.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.SourceGenerator/TestServicesSourceGenerator.cs
@@ -1414,7 +1414,7 @@ namespace Microsoft.VisualStudio
                     if (hasEditorConstants)
                     {
                         if (compilation.GetTypeByMetadataName("Microsoft.VisualStudio.Editor.EditorConstants+EditorCommandID") is { } editorConstantsEditorCommandID
-                            && editorConstantsEditorCommandID.GetAttributes().Any(attribute => attribute.AttributeClass.Name == nameof(GuidAttribute)))
+                            && editorConstantsEditorCommandID.GetAttributes().Any(attribute => attribute.AttributeClass?.Name == nameof(GuidAttribute)))
                         {
                             editorConstantsCommandIDMissingGuid = false;
                         }


### PR DESCRIPTION
Note for the upload-artifacte:

v1/v2 produces the following error.

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/


v3 produces the following erro.

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
