### PR TITLE
Fix exception when retrying test

### DIFF
--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeTestAssemblyRunner.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeTestAssemblyRunner.cs
@@ -303,6 +303,7 @@ namespace Xunit.Harness
                     var previousException = WpfTestSharedData.Instance.Exception;
                     try
                     {
+                        // Run the tests again, but using an error reporting test runner that will report the exception.
                         WpfTestSharedData.Instance.Exception = e;
                         return await RunTestCollectionForUnspecifiedVersionAsync(completedTestCaseIds, messageBus, testCollection, testCases, cancellationTokenSource).ConfigureAwait(true);
                     }
@@ -455,7 +456,12 @@ namespace Xunit.Harness
                             testCaseFinished.TestsSkipped + testCaseFinished.TestsFailed);
                     }
 
-                    return !_cancellationToken.IsCancellationRequested;
+                    if (_cancellationToken.IsCancellationRequested)
+                    {
+                        return false;
+                    }
+
+                    return _messageSink.OnMessage(message);
                 }
                 else if (!_finalAttempt && message is ITestFailed testFailed)
                 {

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeTestFrameworkExecutor.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Harness/IdeTestFrameworkExecutor.cs
@@ -19,15 +19,9 @@ namespace Xunit.Harness
         [SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Follows pattern expected by Xunit framework.")]
         protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
         {
-            try
+            using (var assemblyRunner = new IdeTestAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
             {
-                using (var assemblyRunner = new IdeTestAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
-                {
-                    await assemblyRunner.RunAsync();
-                }
-            }
-            catch
-            {
+                await assemblyRunner.RunAsync();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseRunner.cs
+++ b/src/Microsoft.VisualStudio.Extensibility.Testing.Xunit.Shared/Threading/IdeTestCaseRunner.cs
@@ -43,15 +43,16 @@ namespace Xunit.Threading
 
         protected override XunitTestRunner CreateTestRunner(ITest test, IMessageBus messageBus, Type testClass, object?[] constructorArguments, MethodInfo testMethod, object?[]? testMethodArguments, string skipReason, IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
         {
-            if (Process.GetCurrentProcess().ProcessName == "devenv")
+            if (SharedData.Exception is not null)
+            {
+                // There was an exception in the test harness running this test previously. Report the failure in we saw in the test harness.
+                return new ErrorReportingIdeTestRunner(SharedData.Exception, test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource);
+            }
+            else if (Process.GetCurrentProcess().ProcessName == "devenv")
             {
                 // We are already running inside Visual Studio
                 // TODO: Verify version under test
                 return new InProcessIdeTestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource);
-            }
-            else if (SharedData.Exception is not null)
-            {
-                return new ErrorReportingIdeTestRunner(SharedData.Exception, test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource);
             }
             else
             {


### PR DESCRIPTION
Also don't swallow any xunit harness exception that occurs in the actual xunit infrastructure.